### PR TITLE
Updating entrypoints for setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,8 +25,8 @@ setup(
 	entry_points=\
 	"""
         [ckan.plugins]
-	datajson=ckanext.datajson:DataJsonPlugin
-	datajson_harvest=ckanext.datajson:DataJsonHarvester
-	cmsdatanav_harvest=ckanext.datajson:CmsDataNavigatorHarvester
+	datajson=ckanext.datajson.plugin:DataJsonPlugin
+	datajson_harvest=ckanext.datajson.harvester_datajson:DataJsonHarvester
+	cmsdatanav_harvest=ckanext.datajson.harvester_cmsdatanavigator:CmsDataNavigatorHarvester
 	""",
 )


### PR DESCRIPTION
I was having issues using the `datajson` plugin when running ckan.  I would get this Error when running `paster`.
  
```
Traceback (most recent call last):
  File "/usr/local/bin/paster", line 11, in <module>
    sys.exit(run())
  File "/usr/local/lib/python2.7/dist-packages/paste/script/command.py", line 102, in run
    invoke(command, command_name, options, args[1:])
  File "/usr/local/lib/python2.7/dist-packages/paste/script/command.py", line 141, in invoke
    exit_code = runner.run(args)
  File "/usr/local/lib/python2.7/dist-packages/paste/script/command.py", line 236, in run
    result = self.command()
  File "/usr/lib/ckan/src/ckan/ckan/lib/cli.py", line 333, in command
    self._load_config(cmd!='upgrade')
  File "/usr/lib/ckan/src/ckan/ckan/lib/cli.py", line 306, in _load_config
    self.site_user = load_config(self.options.config, load_site_user)
  File "/usr/lib/ckan/src/ckan/ckan/lib/cli.py", line 221, in load_config
    load_environment(conf.global_conf, conf.local_conf)
  File "/usr/lib/ckan/src/ckan/ckan/config/environment.py", line 99, in load_environment
    p.load_all()
  File "/usr/lib/ckan/src/ckan/ckan/plugins/core.py", line 139, in load_all
    load(*plugins)
  File "/usr/lib/ckan/src/ckan/ckan/plugins/core.py", line 153, in load
    service = _get_service(plugin)
  File "/usr/lib/ckan/src/ckan/ckan/plugins/core.py", line 256, in _get_service
    return plugin.load()(name=plugin_name)
  File "/usr/local/lib/python2.7/dist-packages/pkg_resources/__init__.py", line 2408, in load
    return self.resolve()
  File "/usr/local/lib/python2.7/dist-packages/pkg_resources/__init__.py", line 2418, in resolve
    raise ImportError(str(exc))
ImportError: 'module' object has no attribute 'DataJsonPlugin'
```

After digging I found this https://github.com/GSA/ckanext-datajson/commit/26fea5eab63e1419d2f1c54c890c2a2019a4a8a0

For whatever reason in our `Release-1.24` `__init__.py` file branch we don't have those imports https://github.com/OpenGov-OpenData/ckanext-datajson/blob/Release-1.24/ckanext/__init__.py so the `setup.py` is looking in the wrong place for `DataJsonPlugin`.  With this change I'm able to successfully install and run `paster` with this command.

I'm unsure how this works on our instances today, is there drift from this branch and what is actually used on the servers?