### PR TITLE
[OD-605] Fix logic to generate org data json and use non-federal validation

### DIFF
--- a/ckanext/datajson/build_datajson.py
+++ b/ckanext/datajson/build_datajson.py
@@ -180,9 +180,9 @@ def make_datajson_entry(package):
         ]
 
         for pair in [
-            ('bureauCode', 'bureau_code'),  # required
+            #('bureauCode', 'bureau_code'),  # required
             ('language', 'language'),   # optional
-            ('programCode', 'program_code'),    # required
+            #('programCode', 'program_code'),    # required
             ('references', 'related_documents'),    # optional
             ('theme', 'category'),  # optional
         ]:
@@ -287,7 +287,8 @@ def generate_distribution(package):
         if 'url' in rkeys:
             res_url = strip_if_string(r.get('url'))
             if res_url:
-                if 'api' == r.get('resource_type') or 'accessurl' == r.get('resource_type'):
+                if r.get('resource_type') in ['listing', 'service', 'api'] or \
+                        r.get('url_type') not in ['upload', 'datastore']:
                     resource += [("accessURL", res_url)]
                 else:
                     if res_url.startswith('/datastore/dump/'):

--- a/ckanext/datajson/datajsonvalidator.py
+++ b/ckanext/datajson/datajsonvalidator.py
@@ -121,20 +121,20 @@ def do_validation(doc, errors_array):
                               "A dataset appears with accessLevel set to \"non-public\".", dataset_name)
 
             # bureauCode # required
-            if check_required_field(item, "bureauCode", list, dataset_name, errs):
-                for bc in item["bureauCode"]:
-                    if not isinstance(bc, (str, unicode)):
-                        add_error(errs, 5, "Invalid Required Field Value", "Each bureauCode must be a string",
-                                  dataset_name)
-                    elif ":" not in bc:
-                        add_error(errs, 5, "Invalid Required Field Value",
-                                  "The bureau code \"%s\" is invalid. "
-                                  "Start with the agency code, then a colon, then the bureau code." % bc,
-                                  dataset_name)
-                    elif bc not in omb_burueau_codes:
-                        add_error(errs, 5, "Invalid Required Field Value",
-                                  "The bureau code \"%s\" was not found in our list "
-                                  "(https://project-open-data.cio.gov/data/omb_bureau_codes.csv)." % bc, dataset_name)
+            #if check_required_field(item, "bureauCode", list, dataset_name, errs):
+            #    for bc in item["bureauCode"]:
+            #        if not isinstance(bc, (str, unicode)):
+            #            add_error(errs, 5, "Invalid Required Field Value", "Each bureauCode must be a string",
+            #                      dataset_name)
+            #        elif ":" not in bc:
+            #            add_error(errs, 5, "Invalid Required Field Value",
+            #                      "The bureau code \"%s\" is invalid. "
+            #                      "Start with the agency code, then a colon, then the bureau code." % bc,
+            #                      dataset_name)
+            #        elif bc not in omb_burueau_codes:
+            #            add_error(errs, 5, "Invalid Required Field Value",
+            #                      "The bureau code \"%s\" was not found in our list "
+            #                      "(https://project-open-data.cio.gov/data/omb_bureau_codes.csv)." % bc, dataset_name)
 
             # contactPoint # required
             if check_required_field(item, "contactPoint", dict, dataset_name, errs):
@@ -186,14 +186,14 @@ def do_validation(doc, errors_array):
                               "The field \"modified\" is not in valid format: \"%s\"" % item['modified'], dataset_name)
 
             # programCode # required
-            if check_required_field(item, "programCode", list, dataset_name, errs):
-                for pc in item["programCode"]:
-                    if not isinstance(pc, (str, unicode)):
-                        add_error(errs, 5, "Invalid Required Field Value",
-                                  "Each programCode in the programCode array must be a string", dataset_name)
-                    elif not PROGRAM_CODE_REGEX.match(pc):
-                        add_error(errs, 50, "Invalid Field Value (Optional Fields)",
-                                  "One of programCodes is not in valid format (ex. 018:001): \"%s\"" % pc, dataset_name)
+            #if check_required_field(item, "programCode", list, dataset_name, errs):
+            #    for pc in item["programCode"]:
+            #        if not isinstance(pc, (str, unicode)):
+            #            add_error(errs, 5, "Invalid Required Field Value",
+            #                      "Each programCode in the programCode array must be a string", dataset_name)
+            #        elif not PROGRAM_CODE_REGEX.match(pc):
+            #            add_error(errs, 50, "Invalid Field Value (Optional Fields)",
+            #                      "One of programCodes is not in valid format (ex. 018:001): \"%s\"" % pc, dataset_name)
 
             # publisher # required
             if check_required_field(item, "publisher", dict, dataset_name, errs):

--- a/ckanext/datajson/plugin.py
+++ b/ckanext/datajson/plugin.py
@@ -16,7 +16,8 @@ def get_validator():
     import os
     from jsonschema import Draft4Validator, FormatChecker
 
-    schema_path = os.path.join(os.path.dirname(__file__), 'schema', 'federal-v1.1', 'dataset.json')
+    #schema_path = os.path.join(os.path.dirname(__file__), 'schema', 'federal-v1.1', 'dataset.json')
+    schema_path = os.path.join(os.path.dirname(__file__), 'schema', 'nonfederal-v1.1', 'dataset.json')
     with open(schema_path, 'r') as file:
         schema = json.loads(file.read())
         return Draft4Validator(schema, format_checker=FormatChecker())
@@ -75,12 +76,12 @@ class DataJsonPlugin(p.SingletonPlugin):
 
         # TODO DWC update action
         # /data/{org}/data.json
-        m.connect('public_data_listing', '/organization/{org}/data.json',
+        m.connect('public_data_listing', '/organization/{id}/data.json',
                   controller='ckanext.datajson.plugin:DataJsonController', action='generate_pdl')
 
         # TODO DWC update action
         # /data/{org}/edi.json
-        m.connect('enterprise_data_inventory', '/organization/{org}/edi.json',
+        m.connect('enterprise_data_inventory', '/organization/{id}/edi.json',
                   controller='ckanext.datajson.plugin:DataJsonController', action='generate_edi')
 
         # /pod/validate
@@ -161,31 +162,23 @@ class DataJsonController(BaseController):
 
         return render('datajsonvalidator.html')
 
-    def generate_pdl(self):
-        # DWC this is a hack, as I couldn't get to the request parameters. For whatever reason, the multidict was always empty
-        match = re.match(r"/organization/([-a-z0-9]+)/data.json", request.path)
-        if match:
-            # set content type (charset required or pylons throws an error)
-            response.content_type = 'application/json; charset=UTF-8'
+    def generate_pdl(self, id):
+        # set content type (charset required or pylons throws an error)
+        response.content_type = 'application/json; charset=UTF-8'
 
-            # allow caching of response (e.g. by Apache)
-            del response.headers["Cache-Control"]
-            del response.headers["Pragma"]
-            return make_pdl(match.group(1))
-        return "Invalid organization id"
+        # allow caching of response (e.g. by Apache)
+        del response.headers["Cache-Control"]
+        del response.headers["Pragma"]
+        return make_pdl(id)
 
-    def generate_edi(self):
-        # DWC this is a hack, as I couldn't get to the request parameters. For whatever reason, the multidict was always empty
-        match = re.match(r"/organization/([-a-z0-9]+)/edi.json", request.path)
-        if match:
-            # set content type (charset required or pylons throws an error)
-            response.content_type = 'application/json; charset=UTF-8'
+    def generate_edi(self, id):
+        # set content type (charset required or pylons throws an error)
+        response.content_type = 'application/json; charset=UTF-8'
 
-            # allow caching of response (e.g. by Apache)
-            del response.headers["Cache-Control"]
-            del response.headers["Pragma"]
-            return make_edi(match.group(1))
-        return "Invalid organization id"
+        # allow caching of response (e.g. by Apache)
+        del response.headers["Cache-Control"]
+        del response.headers["Pragma"]
+        return make_edi(id)
 
 
 def make_json():
@@ -217,7 +210,7 @@ def make_json():
     return output
 
 
-def make_edi(owner_org):
+def make_edi(org_id):
     # Error handler for creating error log
     stream = StringIO.StringIO()
     eh = logging.StreamHandler(stream)
@@ -227,10 +220,10 @@ def make_edi(owner_org):
     logger.addHandler(eh)
 
     # Build the data.json file.
-    packages = get_all_group_packages(group_id=owner_org)
+    packages = get_all_group_packages(group_id=org_id)
     output = []
     for pkg in packages:
-        if pkg['owner_org'] == owner_org:
+        if pkg['owner_org'] == org_id or pkg.get('organization',{}).get('name') == org_id:
             datajson_entry = make_datajson_entry(pkg)
             if datajson_entry and is_valid(datajson_entry):
                 output.append(datajson_entry)
@@ -248,7 +241,7 @@ def make_edi(owner_org):
     return write_zip(output, error, zip_name='edi')
 
 
-def make_pdl(owner_org):
+def make_pdl(org_id):
     # Error handler for creating error log
     stream = StringIO.StringIO()
     eh = logging.StreamHandler(stream)
@@ -259,13 +252,13 @@ def make_pdl(owner_org):
 
 
     # Build the data.json file.
-    packages = get_all_group_packages(group_id=owner_org)
+    packages = get_all_group_packages(group_id=org_id)
 
     output = []
     #Create data.json only using public datasets, datasets marked non-public are not exposed
     for pkg in packages:
         try:
-            if pkg['owner_org'] == owner_org and not pkg['private']:
+            if (pkg['owner_org'] == org_id or pkg.get('organization',{}).get('name') == org_id) and not pkg['private']:
                 datajson_entry = make_datajson_entry(pkg)
                 if datajson_entry and is_valid(datajson_entry):
                     output.append(datajson_entry)
@@ -273,7 +266,7 @@ def make_pdl(owner_org):
                     logger.warn("Dataset id=[%s], title=[%s] omitted\n", pkg.get('id', None), pkg.get('title', None))
 
         except KeyError:
-            logger.warn("Dataset id=[%s], title=['%s'] missing required 'public_access_level' field",
+            logger.warn("Dataset id=[%s], title=['%s'] missing required field",
                         pkg.get('id', None), pkg.get('title', None))
             pass
 
@@ -284,8 +277,7 @@ def make_pdl(owner_org):
     logger.removeHandler(eh)
     stream.close()
 
-    #return json.dumps(output)
-    return write_zip(output, error, zip_name='pdl')
+    return json.dumps(output)
 
 
 def get_all_group_packages(group_id):
@@ -339,4 +331,3 @@ def write_zip(data, error=None, zip_name='data'):
     response.content_disposition = 'attachment; filename="%s.zip"' % zip_name
 
     return binary
-

--- a/ckanext/datajson/schema/nonfederal-v1.1/catalog.json
+++ b/ckanext/datajson/schema/nonfederal-v1.1/catalog.json
@@ -1,0 +1,58 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "id": "https://project-open-data.cio.gov/v1.1/schema/catalog.json#",
+  "title": "Project Open Data Catalog",
+  "description": "Validates an entire collection of common core metadata JSON objects. Agencies produce said collections in the form of Data.json files.",
+  "type": "object",
+  "dependencies": {
+    "@type": [
+      "@context"
+    ]
+  },
+  "required": [
+    "conformsTo",
+    "dataset"
+  ],
+  "properties": {
+    "@context": {
+      "title": "Metadata Context",
+      "description": "URL or JSON object for the JSON-LD Context that defines the schema used",
+      "type": "string",
+      "format": "uri"
+    },
+    "@id": {
+      "title": "Metadata Catalog ID",
+      "description": "IRI for the JSON-LD Node Identifier of the Catalog. This should be the URL of the data.json file itself.",
+      "type": "string",
+      "format": "uri"
+    },
+    "@type": {
+      "title": "Metadata Context",
+      "description": "IRI for the JSON-LD data type. This should be dcat:Catalog for the Catalog",
+      "enum": [
+        "dcat:Catalog"
+      ]
+    },
+    "conformsTo": {
+      "description": "Version of Schema",
+      "title": "Version of Schema",
+      "enum": [
+        "https://project-open-data.cio.gov/v1.1/schema"
+      ]
+    },
+    "describedBy": {
+      "description": "URL for the JSON Schema file that defines the schema used",
+      "title": "Data Dictionary",
+      "type": "string",
+      "format": "uri"
+    },
+    "dataset": {
+      "type": "array",
+      "items": {
+        "$ref": "dataset.json",
+        "minItems": 1,
+        "uniqueItems": true
+      }
+    }
+  }
+}

--- a/ckanext/datajson/schema/nonfederal-v1.1/dataset.json
+++ b/ckanext/datajson/schema/nonfederal-v1.1/dataset.json
@@ -1,0 +1,550 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "id": "https://project-open-data.cio.gov/v1.1/schema/dataset.json#",
+  "title": "Project Open Data Dataset",
+  "description": "The metadata format for open data. Validates a single JSON object entry (as opposed to entire Data.json catalog).",
+  "type": "object",
+  "required": [
+    "title",
+    "description",
+    "keyword",
+    "modified",
+    "publisher",
+    "contactPoint",
+    "identifier",
+    "accessLevel"
+  ],
+  "properties": {
+    "@type": {
+      "title": "Metadata Context",
+      "description": "IRI for the JSON-LD data type. This should be dcat:Dataset for each Dataset",
+      "enum": [
+        "dcat:Dataset"
+      ]
+    },
+    "accessLevel": {
+      "description": "The degree to which this dataset could be made publicly-available, regardless of whether it has been made available. Choices: public (Data asset is or could be made publicly available to all without restrictions), restricted public (Data asset is available under certain use restrictions), or non-public (Data asset is not available to members of the public)",
+      "title": "Public Access Level",
+      "enum": [
+        "public",
+        "restricted public",
+        "non-public"
+      ]
+    },
+    "rights": {
+      "title": "Rights",
+      "description": "This may include information regarding access or restrictions based on privacy, security, or other policies. This should also provide an explanation for the selected \"accessLevel\" including instructions for how to access a restricted file, if applicable, or explanation for why a \"non-public\" or \"restricted public\" data assetis not \"public,\" if applicable. Text, 255 characters.",
+      "anyOf": [
+        {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 255
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "accrualPeriodicity": {
+      "title": "Frequency",
+      "description": "Frequency with which dataset is published.",
+      "anyOf": [
+        {
+          "enum": [
+            "irregular"
+          ]
+        },
+        {
+          "type": "string",
+          "pattern": "^R\\/P(?:\\d+(?:\\.\\d+)?Y)?(?:\\d+(?:\\.\\d+)?M)?(?:\\d+(?:\\.\\d+)?W)?(?:\\d+(?:\\.\\d+)?D)?(?:T(?:\\d+(?:\\.\\d+)?H)?(?:\\d+(?:\\.\\d+)?M)?(?:\\d+(?:\\.\\d+)?S)?)?$"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "contactPoint": {
+      "$ref": "vcard.json"
+    },
+    "describedBy": {
+      "title": "Data Dictionary",
+      "description": "URL to the data dictionary for the dataset or API. Note that documentation other than a data dictionary can be referenced using Related Documents as shown in the expanded fields.",
+      "anyOf": [
+        {
+          "type": "string",
+          "format": "uri"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "describedByType": {
+      "title": "Data Dictionary Type",
+      "description": "The machine-readable file format (IANA Media Type or MIME Type) of the distribution’s describedBy URL",
+      "anyOf": [
+        {
+          "pattern": "^[-\\w]+/[-\\w]+(\\.[-\\w]+)*([+][-\\w]+)?$",
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "conformsTo": {
+      "title": "Data Standard",
+      "description": "URI used to identify a standardized specification the dataset conforms to",
+      "anyOf": [
+        {
+          "type": "string",
+          "format": "uri"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "dataQuality": {
+      "title": "Data Quality",
+      "description": "Whether the dataset meets the agency’s Information Quality Guidelines (true/false).",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "description": {
+      "title": "Description",
+      "description": "Human-readable description (e.g., an abstract) with sufficient detail to enable a user to quickly understand whether the asset is of interest.",
+      "type": "string",
+      "minLength": 1
+    },
+    "distribution": {
+      "title": "Distribution",
+      "description": "A container for the array of Distribution objects",
+      "anyOf": [
+        {
+          "type": "array",
+          "items": {
+            "$ref": "distribution.json",
+            "minItems": 1,
+            "uniqueItems": true
+          }
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "identifier": {
+      "title": "Unique Identifier",
+      "description": "A unique identifier for the dataset or API as maintained within an Agency catalog or database.",
+      "type": "string",
+      "minLength": 1
+    },
+    "issued": {
+      "title": "Release Date",
+      "description": "Date of formal issuance.",
+      "anyOf": [
+        {
+          "type": "string",
+          "pattern": "^([\\+-]?\\d{4}(?!\\d{2}\\b))((-?)((0[1-9]|1[0-2])(\\3([12]\\d|0[1-9]|3[01]))?|W([0-4]\\d|5[0-2])(-?[1-7])?|(00[1-9]|0[1-9]\\d|[12]\\d{2}|3([0-5]\\d|6[1-6])))([T\\s]((([01]\\d|2[0-3])((:?)[0-5]\\d)?|24\\:?00)([\\.,]\\d+(?!:))?)?(\\17[0-5]\\d([\\.,]\\d+)?)?([zZ]|([\\+-])([01]\\d|2[0-3]):?([0-5]\\d)?)?)?)?$"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "keyword": {
+      "title": "Tags",
+      "description": "Tags (or keywords) help users discover your dataset; please include terms that would be used by technical and non-technical users.",
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      },
+      "minItems": 1
+    },
+    "landingPage": {
+      "title": "Homepage URL",
+      "description": "Alternative landing page used to redirect user to a contextual, Agency-hosted “homepage” for the Dataset or API when selecting this resource from the Data.gov user interface.",
+      "anyOf": [
+        {
+          "type": "string",
+          "format": "uri"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "language": {
+      "title": "Language",
+      "description": "The language of the dataset.",
+      "anyOf": [
+        {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "pattern": "^(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)|((en-GB-oed|i-ami|i-bnn|i-default|i-enochian|i-hak|i-klingon|i-lux|i-mingo|i-navajo|i-pwn|i-tao|i-tay|i-tsu|sgn-BE-FR|sgn-BE-NL|sgn-CH-DE)|(art-lojban|cel-gaulish|no-bok|no-nyn|zh-guoyu|zh-hakka|zh-min|zh-min-nan|zh-xiang)))$"
+          }
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "license": {
+      "title": "License",
+      "description": "The license dataset or API is published with. See <a href=\"https://project-open-data.cio.gov/open-licenses/\">Open Licenses</a> for more information.",
+      "anyOf": [
+        {
+          "type": "string",
+          "format": "uri"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "modified": {
+      "title": "Last Update",
+      "description": "Most recent date on which the dataset was changed, updated or modified.",
+      "anyOf": [
+        {
+          "type": "string",
+          "pattern": "^([\\+-]?\\d{4}(?!\\d{2}\\b))((-?)((0[1-9]|1[0-2])(\\3([12]\\d|0[1-9]|3[01]))?|W([0-4]\\d|5[0-2])(-?[1-7])?|(00[1-9]|0[1-9]\\d|[12]\\d{2}|3([0-5]\\d|6[1-6])))([T\\s]((([01]\\d|2[0-3])((:?)[0-5]\\d)?|24\\:?00)([\\.,]\\d+(?!:))?)?(\\17[0-5]\\d([\\.,]\\d+)?)?([zZ]|([\\+-])([01]\\d|2[0-3]):?([0-5]\\d)?)?)?)?$"
+        },
+        {
+          "type": "string",
+          "pattern": "^(R\\d*\\/)?P(?:\\d+(?:\\.\\d+)?Y)?(?:\\d+(?:\\.\\d+)?M)?(?:\\d+(?:\\.\\d+)?W)?(?:\\d+(?:\\.\\d+)?D)?(?:T(?:\\d+(?:\\.\\d+)?H)?(?:\\d+(?:\\.\\d+)?M)?(?:\\d+(?:\\.\\d+)?S)?)?$"
+        },
+        {
+          "type": "string",
+          "pattern": "^(R\\d*\\/)?([\\+-]?\\d{4}(?!\\d{2}\\b))((-?)((0[1-9]|1[0-2])(\\4([12]\\d|0[1-9]|3[01]))?|W([0-4]\\d|5[0-2])(-?[1-7])?|(00[1-9]|0[1-9]\\d|[12]\\d{2}|3([0-5]\\d|6[1-6])))([T\\s]((([01]\\d|2[0-3])((:?)[0-5]\\d)?|24\\:?00)([\\.,]\\d+(?!:))?)?(\\18[0-5]\\d([\\.,]\\d+)?)?([zZ]|([\\+-])([01]\\d|2[0-3]):?([0-5]\\d)?)?)?)?(\\/)P(?:\\d+(?:\\.\\d+)?Y)?(?:\\d+(?:\\.\\d+)?M)?(?:\\d+(?:\\.\\d+)?W)?(?:\\d+(?:\\.\\d+)?D)?(?:T(?:\\d+(?:\\.\\d+)?H)?(?:\\d+(?:\\.\\d+)?M)?(?:\\d+(?:\\.\\d+)?S)?)?$"
+        }
+      ]
+    },
+    "primaryITInvestmentUII": {
+      "title": "Primary IT Investment UII",
+      "description": "For linking a dataset with an IT Unique Investment Identifier (UII)",
+      "anyOf": [
+        {
+          "type": "string",
+          "pattern": "[0-9]{3}-[0-9]{9}"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "publisher": {
+      "$ref": "organization.json"
+    },
+    "references": {
+      "title": "Related Documents",
+      "description": "Related documents such as technical information about a dataset, developer documentation, etc.",
+      "anyOf": [
+        {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "format": "uri"
+          },
+          "minItems": 1,
+          "uniqueItems": true
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "spatial": {
+      "title": "Spatial",
+      "description": "The range of spatial applicability of a dataset. Could include a spatial region like a bounding box or a named place.",
+      "anyOf": [
+        {
+          "type": "string",
+          "minLength": 1
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "systemOfRecords": {
+      "title": "System of Records",
+      "description": "If the systems is designated as a system of records under the Privacy Act of 1974, provide the URL to the System of Records Notice related to this dataset.",
+      "anyOf": [
+        {
+          "type": "string",
+          "minLength": 1
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "temporal": {
+      "title": "Temporal",
+      "description": "The range of temporal applicability of a dataset (i.e., a start and end date of applicability for the data).",
+      "anyOf": [
+        {
+          "type": "string",
+          "pattern": "^([\\+-]?\\d{4}(?!\\d{2}\\b))((-?)((0[1-9]|1[0-2])(\\3([12]\\d|0[1-9]|3[01]))?|W([0-4]\\d|5[0-2])(-?[1-7])?|(00[1-9]|0[1-9]\\d|[12]\\d{2}|3([0-5]\\d|6[1-6])))([T\\s]((([01]\\d|2[0-3])((:?)[0-5]\\d)?|24\\:?00)([\\.,]\\d+(?!:))?)?(\\17[0-5]\\d([\\.,]\\d+)?)?([zZ]|([\\+-])([01]\\d|2[0-3]):?([0-5]\\d)?)?)?)?(\\/)([\\+-]?\\d{4}(?!\\d{2}\\b))((-?)((0[1-9]|1[0-2])(\\3([12]\\d|0[1-9]|3[01]))?|W([0-4]\\d|5[0-2])(-?[1-7])?|(00[1-9]|0[1-9]\\d|[12]\\d{2}|3([0-5]\\d|6[1-6])))([T\\s]((([01]\\d|2[0-3])((:?)[0-5]\\d)?|24\\:?00)([\\.,]\\d+(?!:))?)?(\\17[0-5]\\d([\\.,]\\d+)?)?([zZ]|([\\+-])([01]\\d|2[0-3]):?([0-5]\\d)?)?)?)?$"
+        },
+        {
+          "type": "string",
+          "pattern": "^(R\\d*\\/)?([\\+-]?\\d{4}(?!\\d{2}\\b))((-?)((0[1-9]|1[0-2])(\\4([12]\\d|0[1-9]|3[01]))?|W([0-4]\\d|5[0-2])(-?[1-7])?|(00[1-9]|0[1-9]\\d|[12]\\d{2}|3([0-5]\\d|6[1-6])))([T\\s]((([01]\\d|2[0-3])((:?)[0-5]\\d)?|24\\:?00)([\\.,]\\d+(?!:))?)?(\\18[0-5]\\d([\\.,]\\d+)?)?([zZ]|([\\+-])([01]\\d|2[0-3]):?([0-5]\\d)?)?)?)?(\\/)P(?:\\d+(?:\\.\\d+)?Y)?(?:\\d+(?:\\.\\d+)?M)?(?:\\d+(?:\\.\\d+)?W)?(?:\\d+(?:\\.\\d+)?D)?(?:T(?:\\d+(?:\\.\\d+)?H)?(?:\\d+(?:\\.\\d+)?M)?(?:\\d+(?:\\.\\d+)?S)?)?$"
+        },
+        {
+          "type": "string",
+          "pattern": "^(R\\d*\\/)?P(?:\\d+(?:\\.\\d+)?Y)?(?:\\d+(?:\\.\\d+)?M)?(?:\\d+(?:\\.\\d+)?W)?(?:\\d+(?:\\.\\d+)?D)?(?:T(?:\\d+(?:\\.\\d+)?H)?(?:\\d+(?:\\.\\d+)?M)?(?:\\d+(?:\\.\\d+)?S)?)?\\/([\\+-]?\\d{4}(?!\\d{2}\\b))((-?)((0[1-9]|1[0-2])(\\4([12]\\d|0[1-9]|3[01]))?|W([0-4]\\d|5[0-2])(-?[1-7])?|(00[1-9]|0[1-9]\\d|[12]\\d{2}|3([0-5]\\d|6[1-6])))([T\\s]((([01]\\d|2[0-3])((:?)[0-5]\\d)?|24\\:?00)([\\.,]\\d+(?!:))?)?(\\18[0-5]\\d([\\.,]\\d+)?)?([zZ]|([\\+-])([01]\\d|2[0-3]):?([0-5]\\d)?)?)?)?$"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "isPartOf": {
+      "title": "Collection",
+      "description": "The collection of which the dataset is a subset",
+      "anyOf": [
+        {
+          "type": "string",
+          "minLength": 1
+        }
+      ]
+    },
+    "theme": {
+      "title": "Category",
+      "description": "Main thematic category of the dataset.",
+      "anyOf": [
+        {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "minItems": 1,
+          "uniqueItems": true
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "title": {
+      "title": "Title",
+      "description": "Human-readable name of the asset. Should be in plain English and include sufficient detail to facilitate search and discovery.",
+      "type": "string",
+      "minLength": 1
+    }
+  },
+  "definitions": {
+    "vcard": {
+      "$schema": "http://json-schema.org/draft-04/schema#",
+      "id": "https://project-open-data.cio.gov/v1.1/schema/vcard.json#",
+      "title": "Project Open Data ContactPoint vCard",
+      "description": "A Dataset ContactPoint as a vCard object",
+      "type": "object",
+      "required": [
+        "fn",
+        "hasEmail"
+      ],
+      "properties": {
+        "@type": {
+          "title": "Metadata Context",
+          "description": "IRI for the JSON-LD data type. This should be vcard:Contact for contactPoint",
+          "enum": [
+            "vcard:Contact"
+          ]
+        },
+        "fn": {
+          "title": "Contact Name",
+          "description": "A full formatted name, eg Firstname Lastname",
+          "type": "string",
+          "minLength": 1
+        },
+        "hasEmail": {
+          "title": "Email",
+          "description": "Email address for the contact",
+          "pattern": "^mailto:([\\w.-]+@[\\w.-]+\\.[\\w.-]+)?$",
+          "type": "string"
+        }
+      }
+    },
+    "distribution": {
+      "$schema": "http://json-schema.org/draft-04/schema#",
+      "id": "https://project-open-data.cio.gov/v1.1/schema/distribution.json#",
+      "title": "Project Open Data Distribution",
+      "description": "Validates an entire collection of common core metadata JSON objects. Agencies produce said collections in the form of Data.json files.",
+      "type": "object",
+      "dependencies": {
+        "downloadURL": {
+          "properties": {
+            "mediaType": {
+              "type": "string",
+              "pattern": "^[-\\w]+/[-\\w]+(\\.[-\\w]+)*([+][-\\w]+)?$"
+            }
+          },
+          "required": [
+            "mediaType"
+          ]
+        }
+      },
+      "properties": {
+        "@type": {
+          "title": "Metadata Context",
+          "description": "IRI for the JSON-LD data type. This should be dcat:Distribution for each Distribution",
+          "enum": [
+            "dcat:Distribution"
+          ]
+        },
+        "downloadURL": {
+          "title": "Download URL",
+          "description": "URL providing direct access to a downloadable file of a dataset",
+          "type": "string",
+          "format": "uri"
+        },
+        "mediaType": {
+          "title": "Media Type",
+          "description": "The machine-readable file format (IANA Media Type or MIME Type) of the distribution’s downloadURL",
+          "anyOf": [
+            {
+              "pattern": "^[-\\w]+/[-\\w]+(\\.[-\\w]+)*([+][-\\w]+)?$",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "format": {
+          "title": "Format",
+          "description": "A human-readable description of the file format of a distribution",
+          "anyOf": [
+            {
+              "type": "string",
+              "minLength": 1
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "accessURL": {
+          "title": "Access URL",
+          "description": "URL providing indirect access to a dataset",
+          "anyOf": [
+            {
+              "type": "string",
+              "format": "uri"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "description": {
+          "title": "Description",
+          "description": "Human-readable description of the distribution",
+          "anyOf": [
+            {
+              "type": "string",
+              "minLength": 1
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "title": {
+          "title": "Title",
+          "description": "Human-readable name of the distribution",
+          "anyOf": [
+            {
+              "type": "string",
+              "minLength": 1
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "conformsTo": {
+          "title": "Data Standard",
+          "description": "URL providing indirect access to a dataset",
+          "anyOf": [
+            {
+              "type": "string",
+              "format": "uri"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "describedBy": {
+          "title": "Data Dictionary",
+          "description": "URL to the data dictionary for the distribution found at the downloadURL",
+          "anyOf": [
+            {
+              "type": "string",
+              "format": "uri"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "describedByType": {
+          "title": "Data Dictionary Type",
+          "description": "The machine-readable file format (IANA Media Type or MIME Type) of the distribution’s describedBy URL",
+          "anyOf": [
+            {
+              "pattern": "^[-\\w]+/[-\\w]+(\\.[-\\w]+)*([+][-\\w]+)?$",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      }
+    },
+    "organization": {
+      "$schema": "http://json-schema.org/draft-04/schema#",
+      "id": "https://project-open-data.cio.gov/v1.1/schema/organization.json#",
+      "title": "Project Open Data Organization",
+      "description": "A Dataset Publisher Organization as a foaf:Agent object",
+      "type": "object",
+      "required": [
+        "name"
+      ],
+      "properties": {
+        "@type": {
+          "title": "Metadata Context",
+          "description": "IRI for the JSON-LD data type. This should be org:Organization for each publisher",
+          "enum": [
+            "org:Organization"
+          ]
+        },
+        "name": {
+          "title": "Publisher Name",
+          "description": "A full formatted name, eg Firstname Lastname",
+          "type": "string",
+          "minLength": 1
+        },
+        "subOrganizationOf": {
+          "title": "Parent Organization",
+          "$ref": "organization.json"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
[OD-605](https://opengovinc.atlassian.net/browse/OD-605) - Create per Organization harvest end points

## Description
Implement data.json endpoints for organizations.

Changes:
* Fix logic to generate organization data.json (previously only used owner_org)
* Remove the fields bureauCode and programCode from validation, they are for federal use

## Test Procedure
* Install CKAN and ckanext-datajson
* Checkout this PR
* Restart CKAN
* Visit an organization with datasets
* Add /data.json to the organization url (eg: /organization/dwr/data.json)

## Approval Criteria
* The organization data.json should contain metadata about the organization's datasets
* Private datasets should not appear in the data.json