### PR TITLE
[OD-1087] Add missing fields for schema

### DIFF
--- a/ckanext/datajson/build_datajson.py
+++ b/ckanext/datajson/build_datajson.py
@@ -297,12 +297,12 @@ def generate_distribution(package):
                         if site_url:
                             res_url = site_url + res_url
                     resource += [("downloadURL", res_url)]
-                    if 'format' in rkeys:
-                        res_format = strip_if_string(r.get('format'))
-                        if res_format:
-                            resource += [("mediaType", res_format)]
-                    else:
-                        log.warn("Missing mediaType for resource in package ['%s']", package.get('id'))
+                if 'format' in rkeys:
+                    res_format = strip_if_string(r.get('format'))
+                    if res_format:
+                        resource += [("mediaType", res_format)]
+                else:
+                    log.warn("Missing mediaType for resource in package ['%s']", package.get('id'))
         else:
             log.warn("Missing downloadURL for resource in package ['%s']", package.get('id'))
 

--- a/ckanext/datajson/build_datajson.py
+++ b/ckanext/datajson/build_datajson.py
@@ -47,12 +47,13 @@ def make_datajson_entry(package):
         extras['category'] = extras['category'].replace(geospatial_group,'geospatial')
 
     # if there is no contact_email, set a default email
-    if not extras.get('contact_name') and not extras.get('contact_email'):
+    if not extras.get('contact_name'):
         contact_name = config.get('ckanext.datajson.contact_name', config.get('email_to'))
+        extras['contact_name'] = package.get('contact_name') or contact_name
+
+    if not extras.get('contact_email'):
         contact_email = config.get('ckanext.datajson.contact_email', config.get('ckan.site_title'))
-        if contact_name and contact_email:
-            extras['contact_name'] = contact_name
-            extras['contact_email'] = contact_email
+        extras['contact_email'] = package.get('contact_email') or contact_email
 
     parent_dataset_id = extras.get('parent_dataset')
     if parent_dataset_id:


### PR DESCRIPTION
Currently the data.json file for organizations only contain dataset list.
It is missing the following fields:
```
{
  @context: "https://project-open-data.cio.gov/v1.1/schema/catalog.jsonld",
  @type: "dcat:Catalog",
  conformsTo: "https://project-open-data.cio.gov/v1.1/schema",
  describedBy: "https://project-open-data.cio.gov/v1.1/schema/catalog.json",
}
```

Also we should be setting the contact_name or contact_email if they are present in the package metadata. This usually occurs with instances that have a custom schema that has either field.

## Testing
- Install the datajson plugin.
- Go to the data.json of an organization with at least 1 dataset.
  - http://127.0.0.1:5000/organization/test-org/data.json
- Check that the data.json only contains a list of dataset(s) and does not contain the missing metadata fields
- Checkout this PR
- Go to the data.json of the organization again and check that it has the following fields
```
{
  "conformsTo": "https://project-open-data.cio.gov/v1.1/schema",
  "describedBy": "https://project-open-data.cio.gov/v1.1/schema/catalog.json",
  "@context": "https://project-open-data.cio.gov/v1.1/schema/catalog.jsonld",
  "@type": "dcat:Catalog",
  "dataset": [
    { "@type": "dcat:Dataset", "title": "Test Dataset 1", ... },
    { "@type": "dcat:Dataset", "title": "Test Dataset 2", ... }
  ]
}
```