### PR TITLE
[OD-1108] Org data json validation

### DIFF
--- a/ckanext/datajson/plugin.py
+++ b/ckanext/datajson/plugin.py
@@ -263,7 +263,8 @@ def make_pdl(org_id):
     #Create data.json only using public datasets, datasets marked non-public are not exposed
     for pkg in packages:
         try:
-            if (pkg['owner_org'] == org_id or pkg.get('organization',{}).get('name') == org_id) and not pkg['private']:
+            if ((pkg['owner_org'] == org_id or pkg.get('organization',{}).get('name') == org_id) and
+            pkg['type'] == 'dataset' and not pkg['private']):
                 datajson_entry = make_datajson_entry(pkg)
                 if datajson_entry and is_valid(datajson_entry):
                     datasets.append(datajson_entry)

--- a/ckanext/datajson/schema/nonfederal-v1.1/dataset.json
+++ b/ckanext/datajson/schema/nonfederal-v1.1/dataset.json
@@ -190,7 +190,7 @@
           "type": "array",
           "items": {
             "type": "string",
-            "minLength": 1
+            "pattern": "^(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)|((en-GB-oed|i-ami|i-bnn|i-default|i-enochian|i-hak|i-klingon|i-lux|i-mingo|i-navajo|i-pwn|i-tao|i-tay|i-tsu|sgn-BE-FR|sgn-BE-NL|sgn-CH-DE)|(art-lojban|cel-gaulish|no-bok|no-nyn|zh-guoyu|zh-hakka|zh-min|zh-min-nan|zh-xiang)|([A-Za-z]{1,8}\\s[A-Za-z()]{1,8})|(\\[[\\W\\w]{1,8}\\])|([Nn]{1}\/[Aa]{1})|([Nn]ot\\s[Ss]pecified)))$"
           }
         },
         {

--- a/ckanext/datajson/schema/nonfederal-v1.1/dataset.json
+++ b/ckanext/datajson/schema/nonfederal-v1.1/dataset.json
@@ -190,7 +190,7 @@
           "type": "array",
           "items": {
             "type": "string",
-            "pattern": "^(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)|((en-GB-oed|i-ami|i-bnn|i-default|i-enochian|i-hak|i-klingon|i-lux|i-mingo|i-navajo|i-pwn|i-tao|i-tay|i-tsu|sgn-BE-FR|sgn-BE-NL|sgn-CH-DE)|(art-lojban|cel-gaulish|no-bok|no-nyn|zh-guoyu|zh-hakka|zh-min|zh-min-nan|zh-xiang)))$"
+            "minLength": 1
           }
         },
         {


### PR DESCRIPTION
The validation requirements for organization specific data.json are too strict. The value "English (EN)" fails validation for the language metadata field.

Also adding a check for package_type for organization data.json file. Only packages where the type is `dataset` should be added, not `harvest` and `showcase`.

## Testing
- Install the datajson plugin.
- Go to the data.json of an organization with at least 1 dataset.
  http://127.0.0.1:5000/organization/test-org/data.json
- Install a custom schema with language as a field
- Datasets should appear in organization specific data.json endpoints even if they have "English (EN)" set in the language metadata field.