### PR TITLE
[OD-1650] Display dcat issued and modified dates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,5 @@
 build
 ckanext_datajson.egg-info
 .DS_Store
-ckanext/datajson/export_map/*.map.json
 .idea
 .vscode/

--- a/ckanext/datajson/export_map/bostonma.map.json
+++ b/ckanext/datajson/export_map/bostonma.map.json
@@ -13,8 +13,13 @@
     "description": {
       "field": "notes"
     },
+    "issued": {
+      "field": "metadata_created",
+      "wrapper": "get_catalog_date"
+    },
     "modified": {
-      "field": "metadata_modified"
+      "field": "metadata_modified",
+      "wrapper": "get_catalog_date"
     },
     "accessLevel": {
       "extra": true,
@@ -39,10 +44,6 @@
     "describedByType": {
       "extra": true,
       "field": "Described by Type"
-    },
-    "issued": {
-      "extra": true,
-      "field": "issued"
     },
     "landingPage": {
       "field": "url"

--- a/ckanext/datajson/export_map/bostonma.map.json
+++ b/ckanext/datajson/export_map/bostonma.map.json
@@ -1,0 +1,144 @@
+{
+  "validation_enabled": false,
+  "catalog_headers": {
+    "conformsTo": "https://project-open-data.cio.gov/v1.1/schema",
+    "describedBy": "https://project-open-data.cio.gov/v1.1/schema/catalog.json",
+    "@context": "https://project-open-data.cio.gov/v1.1/schema/catalog.jsonld",
+    "@type": "dcat:Catalog"
+  },
+  "dataset_fields_map": {
+    "title": {
+      "field": "title"
+    },
+    "description": {
+      "field": "notes"
+    },
+    "modified": {
+      "field": "metadata_modified"
+    },
+    "accessLevel": {
+      "extra": true,
+      "field": "Access Level",
+      "default": "public"
+    },
+    "identifier": {
+      "field": "id"
+    },
+    "dataQuality": {
+      "extra": true,
+      "field": "Data Quality"
+    },
+    "conformsTo": {
+      "extra": true,
+      "field": "Conforms To"
+    },
+    "describedBy": {
+      "extra": true,
+      "field": "Described by"
+    },
+    "describedByType": {
+      "extra": true,
+      "field": "Described by Type"
+    },
+    "issued": {
+      "extra": true,
+      "field": "issued"
+    },
+    "landingPage": {
+      "field": "url"
+    },
+    "license": {
+      "extra": true,
+      "field": "license"
+    },
+    "primaryITInvestmentUII": {
+      "extra": true,
+      "field": "Primary It Investment Uii"
+    },
+    "rights": {
+      "extra": true,
+      "field": "rights"
+    },
+    "systemOfRecords": {
+      "extra": true,
+      "field": "System Of Records"
+    },
+    "spatial": {
+      "extra": true,
+      "field": "Spatial"
+    },
+    "temporal": {
+      "extra": true,
+      "field": "Temporal"
+    },
+    "publisher": {
+      "extra": true,
+      "field": "publisher",
+      "wrapper": "catalog_publisher"
+    },
+    "accrualPeriodicity": {
+      "field": "accrual_periodicity"
+    },
+    "contactPoint": {
+      "wrapper": "build_contact_point",
+      "map": {
+        "fn": {
+          "field": "contact_point"
+        },
+        "hasEmail": {
+          "field": "contact_point_email"
+        }
+      }
+    },
+    "distribution": {
+      "wrapper": "generate_distribution",
+      "map": {
+        "accessURL": {
+          "field": "url"
+        },
+        "mediaType": {
+          "field": "mimetype"
+        },
+        "format": {
+          "field": "format"
+        },
+        "title": {
+          "type": "array",
+          "array_key": "en",
+          "field": "name_translated"
+        },
+        "description": {
+          "field": "description"
+        },
+        "conformsTo": {
+          "field": "conformsTo"
+        },
+        "describedBy": {
+          "field": "describedBy"
+        },
+        "describedByType": {
+          "field": "describedByType"
+        }
+      }
+    },
+    "keyword": {
+      "type": "array",
+      "array_key": "display_name",
+      "field": "tags"
+    },
+    "language": {
+      "field": "language"
+    },
+    "references": {
+      "type": "array",
+      "extra": true,
+      "field": "references",
+      "split": ","
+    },
+    "theme": {
+      "type": "array",
+      "array_key": "display_name",
+      "field": "groups"
+    }
+  }
+}

--- a/ckanext/datajson/export_map/cdt.map.json
+++ b/ckanext/datajson/export_map/cdt.map.json
@@ -1,0 +1,157 @@
+{
+  "validation_enabled": false,
+  "catalog_headers": {
+    "conformsTo": "https://project-open-data.cio.gov/v1.1/schema",
+    "describedBy": "https://project-open-data.cio.gov/v1.1/schema/catalog.json",
+    "@context": "https://project-open-data.cio.gov/v1.1/schema/catalog.jsonld",
+    "@type": "dcat:Catalog"
+  },
+  "dataset_fields_map": {
+    "title": {
+      "field": "title"
+    },
+    "description": {
+      "field": "notes"
+    },
+    "modified": {
+      "field": "metadata_modified"
+    },
+    "accessLevel": {
+      "extra": true,
+      "field": "Access Level",
+      "default": "public"
+    },
+    "identifier": {
+      "field": "id"
+    },
+    "dataQuality": {
+      "extra": true,
+      "field": "Data Quality"
+    },
+    "conformsTo": {
+      "extra": true,
+      "field": "Conforms To"
+    },
+    "describedBy": {
+      "extra": true,
+      "field": "Described by"
+    },
+    "describedByType": {
+      "extra": true,
+      "field": "Described by Type"
+    },
+    "issued": {
+      "extra": true,
+      "field": "issued"
+    },
+    "landingPage": {
+      "field": "program_web_page"
+    },
+    "license": {
+      "extra": true,
+      "field": "license"
+    },
+    "primaryITInvestmentUII": {
+      "extra": true,
+      "field": "Primary It Investment Uii"
+    },
+    "rights": {
+      "extra": true,
+      "field": "rights"
+    },
+    "systemOfRecords": {
+      "extra": true,
+      "field": "System Of Records"
+    },
+    "spatial": {
+      "extra": true,
+      "field": "Spatial"
+    },
+    "temporal": {
+      "field": "temporal_coverage"
+    },
+    "publisher": {
+      "extra": true,
+      "field": "publisher",
+      "wrapper": "catalog_publisher"
+    },
+    "accrualPeriodicity": {
+      "field": "accrual_periodicity",
+      "wrapper": "fix_accrual_periodicity"
+    },
+    "contactPoint": {
+      "wrapper": "build_contact_point",
+      "map": {
+        "fn": {
+          "field": "contact_name"
+        },
+        "hasEmail": {
+          "field": "contact_email"
+        }
+      }
+    },
+    "distribution": {
+      "wrapper": "generate_distribution",
+      "map": {
+        "accessURL": {
+          "field": "url"
+        },
+        "mediaType": {
+          "field": "mimetype"
+        },
+        "format": {
+          "field": "format"
+        },
+        "title": {
+          "field": "name"
+        },
+        "description": {
+          "field": "description"
+        },
+        "conformsTo": {
+          "field": "conformsTo"
+        },
+        "describedBy": {
+          "field": "describedBy"
+        },
+        "describedByType": {
+          "field": "describedByType"
+        }
+      }
+    },
+    "keyword": {
+      "type": "array",
+      "array_key": "display_name",
+      "field": "tags"
+    },
+    "bureauCode": {
+      "type": "array",
+      "extra": true,
+      "field": "Bureau Code",
+      "split": ","
+    },
+    "programCode": {
+      "type": "array",
+      "extra": true,
+      "field": "Program Code",
+      "split": ","
+    },
+    "language": {
+      "type": "array",
+      "extra": true,
+      "field": "Language",
+      "split": ","
+    },
+    "references": {
+      "type": "array",
+      "extra": true,
+      "field": "references",
+      "split": ","
+    },
+    "theme": {
+      "type": "array",
+      "array_key": "display_name",
+      "field": "groups"
+    }
+  }
+}

--- a/ckanext/datajson/export_map/cdt.map.json
+++ b/ckanext/datajson/export_map/cdt.map.json
@@ -13,8 +13,13 @@
     "description": {
       "field": "notes"
     },
+    "issued": {
+      "field": "metadata_created",
+      "wrapper": "get_catalog_date"
+    },
     "modified": {
-      "field": "metadata_modified"
+      "field": "metadata_modified",
+      "wrapper": "get_catalog_date"
     },
     "accessLevel": {
       "extra": true,
@@ -39,10 +44,6 @@
     "describedByType": {
       "extra": true,
       "field": "Described by Type"
-    },
-    "issued": {
-      "extra": true,
-      "field": "issued"
     },
     "landingPage": {
       "field": "program_web_page"

--- a/ckanext/datajson/export_map/chhs.map.json
+++ b/ckanext/datajson/export_map/chhs.map.json
@@ -13,8 +13,13 @@
     "description": {
       "field": "notes"
     },
+    "issued": {
+      "field": "metadata_created",
+      "wrapper": "get_catalog_date"
+    },
     "modified": {
-      "field": "metadata_modified"
+      "field": "metadata_modified",
+      "wrapper": "get_catalog_date"
     },
     "accessLevel": {
       "extra": true,
@@ -39,10 +44,6 @@
     "describedByType": {
       "extra": true,
       "field": "Described by Type"
-    },
-    "issued": {
-      "extra": true,
-      "field": "issued"
     },
     "landingPage": {
       "field": "program_web_page"

--- a/ckanext/datajson/export_map/chhs.map.json
+++ b/ckanext/datajson/export_map/chhs.map.json
@@ -1,0 +1,157 @@
+{
+  "validation_enabled": false,
+  "catalog_headers": {
+    "conformsTo": "https://project-open-data.cio.gov/v1.1/schema",
+    "describedBy": "https://project-open-data.cio.gov/v1.1/schema/catalog.json",
+    "@context": "https://project-open-data.cio.gov/v1.1/schema/catalog.jsonld",
+    "@type": "dcat:Catalog"
+  },
+  "dataset_fields_map": {
+    "title": {
+      "field": "title"
+    },
+    "description": {
+      "field": "notes"
+    },
+    "modified": {
+      "field": "metadata_modified"
+    },
+    "accessLevel": {
+      "extra": true,
+      "field": "Access Level",
+      "default": "public"
+    },
+    "identifier": {
+      "field": "id"
+    },
+    "dataQuality": {
+      "extra": true,
+      "field": "Data Quality"
+    },
+    "conformsTo": {
+      "extra": true,
+      "field": "Conforms To"
+    },
+    "describedBy": {
+      "extra": true,
+      "field": "Described by"
+    },
+    "describedByType": {
+      "extra": true,
+      "field": "Described by Type"
+    },
+    "issued": {
+      "extra": true,
+      "field": "issued"
+    },
+    "landingPage": {
+      "field": "program_web_page"
+    },
+    "license": {
+      "extra": true,
+      "field": "license"
+    },
+    "primaryITInvestmentUII": {
+      "extra": true,
+      "field": "Primary It Investment Uii"
+    },
+    "rights": {
+      "extra": true,
+      "field": "rights"
+    },
+    "systemOfRecords": {
+      "extra": true,
+      "field": "System Of Records"
+    },
+    "spatial": {
+      "extra": true,
+      "field": "Spatial"
+    },
+    "temporal": {
+      "field": "temporal_coverage"
+    },
+    "publisher": {
+      "extra": true,
+      "field": "publisher",
+      "wrapper": "catalog_publisher"
+    },
+    "accrualPeriodicity": {
+      "field": "accrual_periodicity",
+      "wrapper": "fix_accrual_periodicity"
+    },
+    "contactPoint": {
+      "wrapper": "build_contact_point",
+      "map": {
+        "fn": {
+          "field": "author"
+        },
+        "hasEmail": {
+          "field": "contact_email"
+        }
+      }
+    },
+    "distribution": {
+      "wrapper": "generate_distribution",
+      "map": {
+        "accessURL": {
+          "field": "url"
+        },
+        "mediaType": {
+          "field": "mimetype"
+        },
+        "format": {
+          "field": "format"
+        },
+        "title": {
+          "field": "name"
+        },
+        "description": {
+          "field": "description"
+        },
+        "conformsTo": {
+          "field": "conformsTo"
+        },
+        "describedBy": {
+          "field": "describedBy"
+        },
+        "describedByType": {
+          "field": "describedByType"
+        }
+      }
+    },
+    "keyword": {
+      "type": "array",
+      "array_key": "display_name",
+      "field": "tags"
+    },
+    "bureauCode": {
+      "type": "array",
+      "extra": true,
+      "field": "Bureau Code",
+      "split": ","
+    },
+    "programCode": {
+      "type": "array",
+      "extra": true,
+      "field": "Program Code",
+      "split": ","
+    },
+    "language": {
+      "type": "array",
+      "extra": true,
+      "field": "Language",
+      "split": ","
+    },
+    "references": {
+      "type": "array",
+      "extra": true,
+      "field": "references",
+      "split": ","
+    },
+    "theme": {
+      "type": "array",
+      "array_key": "display_name",
+      "field": "groups"
+    }
+  }
+}

--- a/ckanext/datajson/export_map/cnra.map.json
+++ b/ckanext/datajson/export_map/cnra.map.json
@@ -13,8 +13,13 @@
     "description": {
       "field": "notes"
     },
+    "issued": {
+      "field": "metadata_created",
+      "wrapper": "get_catalog_date"
+    },
     "modified": {
-      "field": "metadata_modified"
+      "field": "metadata_modified",
+      "wrapper": "get_catalog_date"
     },
     "accessLevel": {
       "extra": true,
@@ -39,10 +44,6 @@
     "describedByType": {
       "extra": true,
       "field": "Described by Type"
-    },
-    "issued": {
-      "extra": true,
-      "field": "issued"
     },
     "landingPage": {
       "field": "url"

--- a/ckanext/datajson/export_map/cnra.map.json
+++ b/ckanext/datajson/export_map/cnra.map.json
@@ -1,0 +1,142 @@
+{
+  "validation_enabled": false,
+  "catalog_headers": {
+    "conformsTo": "https://project-open-data.cio.gov/v1.1/schema",
+    "describedBy": "https://project-open-data.cio.gov/v1.1/schema/catalog.json",
+    "@context": "https://project-open-data.cio.gov/v1.1/schema/catalog.jsonld",
+    "@type": "dcat:Catalog"
+  },
+  "dataset_fields_map": {
+    "title": {
+      "field": "title"
+    },
+    "description": {
+      "field": "notes"
+    },
+    "modified": {
+      "field": "metadata_modified"
+    },
+    "accessLevel": {
+      "extra": true,
+      "field": "Access Level",
+      "default": "public"
+    },
+    "identifier": {
+      "field": "id"
+    },
+    "dataQuality": {
+      "extra": true,
+      "field": "Data Quality"
+    },
+    "conformsTo": {
+      "extra": true,
+      "field": "Conforms To"
+    },
+    "describedBy": {
+      "extra": true,
+      "field": "Described by"
+    },
+    "describedByType": {
+      "extra": true,
+      "field": "Described by Type"
+    },
+    "issued": {
+      "extra": true,
+      "field": "issued"
+    },
+    "landingPage": {
+      "field": "url"
+    },
+    "license": {
+      "extra": true,
+      "field": "license"
+    },
+    "primaryITInvestmentUII": {
+      "extra": true,
+      "field": "Primary It Investment Uii"
+    },
+    "rights": {
+      "extra": true,
+      "field": "rights"
+    },
+    "systemOfRecords": {
+      "extra": true,
+      "field": "System Of Records"
+    },
+    "spatial": {
+      "extra": true,
+      "field": "Spatial"
+    },
+    "temporal": {
+      "field": "temporal_coverage"
+    },
+    "publisher": {
+      "extra": true,
+      "field": "publisher",
+      "wrapper": "catalog_publisher"
+    },
+    "accrualPeriodicity": {
+      "field": "frequency",
+      "wrapper": "fix_accrual_periodicity"
+    },
+    "contactPoint": {
+      "wrapper": "build_contact_point",
+      "map": {
+        "fn": {
+          "field": "contact_name"
+        },
+        "hasEmail": {
+          "field": "contact_email"
+        }
+      }
+    },
+    "distribution": {
+      "wrapper": "generate_distribution",
+      "map": {
+        "accessURL": {
+          "field": "url"
+        },
+        "mediaType": {
+          "field": "mimetype"
+        },
+        "format": {
+          "field": "format"
+        },
+        "title": {
+          "field": "name"
+        },
+        "description": {
+          "field": "description"
+        },
+        "conformsTo": {
+          "field": "conformsTo"
+        },
+        "describedBy": {
+          "field": "describedBy"
+        },
+        "describedByType": {
+          "field": "describedByType"
+        }
+      }
+    },
+    "keyword": {
+      "type": "array",
+      "array_key": "display_name",
+      "field": "tags"
+    },
+    "language": {
+      "field": "language"
+    },
+    "references": {
+      "type": "array",
+      "extra": true,
+      "field": "references",
+      "split": ","
+    },
+    "theme": {
+      "type": "array",
+      "array_key": "display_name",
+      "field": "groups"
+    }
+  }
+}

--- a/ckanext/datajson/export_map/export.map.json
+++ b/ckanext/datajson/export_map/export.map.json
@@ -13,8 +13,13 @@
     "description": {
       "field": "notes"
     },
+    "issued": {
+      "field": "metadata_created",
+      "wrapper": "get_catalog_date"
+    },
     "modified": {
-      "field": "metadata_modified"
+      "field": "metadata_modified",
+      "wrapper": "get_catalog_date"
     },
     "accessLevel": {
       "extra": true,
@@ -39,10 +44,6 @@
     "describedByType": {
       "extra": true,
       "field": "Described by Type"
-    },
-    "issued": {
-      "extra": true,
-      "field": "issued"
     },
     "landingPage": {
       "extra": true,

--- a/ckanext/datajson/export_map/export.map.json
+++ b/ckanext/datajson/export_map/export.map.json
@@ -1,0 +1,162 @@
+{
+  "validation_enabled": false,
+  "catalog_headers": {
+    "conformsTo": "https://project-open-data.cio.gov/v1.1/schema",
+    "describedBy": "https://project-open-data.cio.gov/v1.1/schema/catalog.json",
+    "@context": "https://project-open-data.cio.gov/v1.1/schema/catalog.jsonld",
+    "@type": "dcat:Catalog"
+  },
+  "dataset_fields_map": {
+    "title": {
+      "field": "title"
+    },
+    "description": {
+      "field": "notes"
+    },
+    "modified": {
+      "field": "metadata_modified"
+    },
+    "accessLevel": {
+      "extra": true,
+      "field": "Access Level",
+      "default": "public"
+    },
+    "identifier": {
+      "field": "id"
+    },
+    "dataQuality": {
+      "extra": true,
+      "field": "Data Quality"
+    },
+    "conformsTo": {
+      "extra": true,
+      "field": "Conforms To"
+    },
+    "describedBy": {
+      "extra": true,
+      "field": "Described by"
+    },
+    "describedByType": {
+      "extra": true,
+      "field": "Described by Type"
+    },
+    "issued": {
+      "extra": true,
+      "field": "issued"
+    },
+    "landingPage": {
+      "extra": true,
+      "field": "landingPage"
+    },
+    "license": {
+      "extra": true,
+      "field": "license"
+    },
+    "primaryITInvestmentUII": {
+      "extra": true,
+      "field": "Primary It Investment Uii"
+    },
+    "rights": {
+      "extra": true,
+      "field": "rights"
+    },
+    "systemOfRecords": {
+      "extra": true,
+      "field": "System Of Records"
+    },
+    "spatial": {
+      "extra": true,
+      "field": "Spatial"
+    },
+    "temporal": {
+      "extra": true,
+      "field": "Temporal"
+    },
+    "publisher": {
+      "extra": true,
+      "field": "publisher",
+      "wrapper": "catalog_publisher"
+    },
+    "accrualPeriodicity": {
+      "extra": true,
+      "field": "Accrual Periodicity",
+      "wrapper": "fix_accrual_periodicity"
+    },
+    "contactPoint": {
+      "wrapper": "build_contact_point",
+      "map": {
+        "fn": {
+          "extra": true,
+          "field": "Responsible Party"
+        },
+        "hasEmail": {
+          "extra": true,
+          "field": "Contact Email"
+        }
+      }
+    },
+    "distribution": {
+      "wrapper": "generate_distribution",
+      "map": {
+        "accessURL": {
+          "field": "url"
+        },
+        "mediaType": {
+          "field": "mimetype"
+        },
+        "format": {
+          "field": "format"
+        },
+        "title": {
+          "field": "name"
+        },
+        "description": {
+          "field": "description"
+        },
+        "conformsTo": {
+          "field": "conformsTo"
+        },
+        "describedBy": {
+          "field": "describedBy"
+        },
+        "describedByType": {
+          "field": "describedByType"
+        }
+      }
+    },
+    "keyword": {
+      "type": "array",
+      "array_key": "display_name",
+      "field": "tags"
+    },
+    "bureauCode": {
+      "type": "array",
+      "extra": true,
+      "field": "Bureau Code",
+      "split": ","
+    },
+    "programCode": {
+      "type": "array",
+      "extra": true,
+      "field": "Program Code",
+      "split": ","
+    },
+    "language": {
+      "type": "array",
+      "extra": true,
+      "field": "Language",
+      "split": ","
+    },
+    "references": {
+      "type": "array",
+      "extra": true,
+      "field": "references",
+      "split": ","
+    },
+    "theme": {
+      "type": "array",
+      "array_key": "display_name",
+      "field": "groups"
+    }
+  }
+}

--- a/ckanext/datajson/helpers.py
+++ b/ckanext/datajson/helpers.py
@@ -200,7 +200,7 @@ class PackageExtraCache:
         try:
             self.pid = package.get('id')
 
-            current_extras = package.get('extras')
+            current_extras = package.get('extras', [])
             new_extras = {}
             for extra in current_extras:
                 if 'extras_rollup' == extra.get('key'):

--- a/ckanext/datajson/package2pod.py
+++ b/ckanext/datajson/package2pod.py
@@ -308,7 +308,8 @@ class Wrappers:
         'irregular': 'irregular',
         'notplanned': 'irregular',
         'unknown': 'irregular',
-        'not updated': 'irregular'
+        'not updated': 'irregular',
+        'other': 'irregular'
     }
 
     @staticmethod
@@ -318,6 +319,10 @@ class Wrappers:
     @staticmethod
     def build_contact_point(someValue):
         import sys, os
+        try:
+            from ckan.common import config
+        except ImportError:
+            from pylons import config
 
         try:
             contact_point_map = Wrappers.full_field_map.get('contactPoint').get('map')
@@ -326,14 +331,26 @@ class Wrappers:
 
             package = Wrappers.pkg
 
+            contact_fields = [('maintainer', 'maintainer_email'),
+                              ('contact_name', 'contact_email'),
+                              ('author', 'author_email')]
+
+            default_name = ''
+            default_email = ''
+            for name_field, email_field in contact_fields:
+                if package.get(name_field) and package.get(email_field):
+                    default_name = name_field
+                    default_email = email_field
+                    break
+
             if contact_point_map.get('fn').get('extra'):
                 fn = get_extra(package, contact_point_map.get('fn').get('field'),
                                get_extra(package, "Contact Name",
-                                         package.get('maintainer')))
+                                         package.get(default_name)))
             else:
                 fn = package.get(contact_point_map.get('fn').get('field'),
                                  get_extra(package, "Contact Name",
-                                           package.get('maintainer')))
+                                           package.get(default_name)))
 
             fn = get_responsible_party(fn)
 
@@ -346,10 +363,10 @@ class Wrappers:
 
             if contact_point_map.get('hasEmail').get('extra'):
                 email = get_extra(package, contact_point_map.get('hasEmail').get('field'),
-                                  package.get('maintainer_email'))
+                                  package.get(default_email))
             else:
                 email = package.get(contact_point_map.get('hasEmail').get('field'),
-                                    package.get('maintainer_email'))
+                                    package.get(default_email))
 
             if email and not is_redacted(email) and '@' in email:
                 email = 'mailto:' + email
@@ -363,10 +380,18 @@ class Wrappers:
                 email = Package2Pod.filter(email)
 
             contact_point = OrderedDict([('@type', 'vcard:Contact')])
+
             if fn:
                 contact_point['fn'] = fn
+            else:
+                contact_point['fn'] = config.get('ckanext.datajson.contact_name',
+                                                 config.get('email_to'))
+
             if email:
                 contact_point['hasEmail'] = email
+            else:
+                contact_point['hasEmail'] = config.get('ckanext.datajson.contact_email',
+                                                       config.get('ckan.site_title'))
 
             return contact_point
         except Exception as e:
@@ -437,8 +462,6 @@ class Wrappers:
                     if 'accessURL' in resource:
                         resource.pop('accessURL')
                     resource['downloadURL'] = res_url
-                    if 'mediaType' not in resource:
-                        log.warn("Missing mediaType for resource in package ['%s']", package.get('id'))
             else:
                 log.warn("Missing downloadURL for resource in package ['%s']", package.get('id'))
 

--- a/ckanext/datajson/package2pod.py
+++ b/ckanext/datajson/package2pod.py
@@ -523,3 +523,15 @@ class Wrappers:
         msg = value + ' ... BECOMES ... ' + mime_type
         log.debug(msg)
         return mime_type
+
+    @staticmethod
+    def get_catalog_date(date_value):
+        dcat_issued = get_extra(Wrappers.pkg, 'dcat_issued')
+        dcat_modified = get_extra(Wrappers.pkg, 'dcat_modified')
+        if dcat_issued and dcat_modified:
+            catalog_date_field = Wrappers.current_field_map.get('field')
+            if catalog_date_field == 'metadata_created':
+                return dcat_issued
+            elif catalog_date_field == 'metadata_modified':
+                return dcat_modified
+        return date_value

--- a/ckanext/datajson/package2pod.py
+++ b/ckanext/datajson/package2pod.py
@@ -464,6 +464,7 @@ class Wrappers:
                     resource['downloadURL'] = res_url
             else:
                 log.warn("Missing downloadURL for resource in package ['%s']", package.get('id'))
+                continue
 
             striped_resource = OrderedDict(
                 [(x, y) for x, y in resource.iteritems() if y is not None and y != "" and y != []])

--- a/ckanext/datajson/package2pod.py
+++ b/ckanext/datajson/package2pod.py
@@ -526,8 +526,13 @@ class Wrappers:
 
     @staticmethod
     def get_catalog_date(date_value):
-        dcat_issued = get_extra(Wrappers.pkg, 'dcat_issued')
-        dcat_modified = get_extra(Wrappers.pkg, 'dcat_modified')
+        dcat_issued = ''
+        dcat_modified = ''
+        for extra in Wrappers.pkg.get('extras', []):
+            if extra['key'] == 'dcat_issued':
+                dcat_issued = extra['value']
+            elif extra['key'] == 'dcat_modified':
+                dcat_modified = extra['value']
         if dcat_issued and dcat_modified:
             catalog_date_field = Wrappers.current_field_map.get('field')
             if catalog_date_field == 'metadata_created':

--- a/ckanext/datajson/plugin.py
+++ b/ckanext/datajson/plugin.py
@@ -199,8 +199,8 @@ class DataJsonController(BaseController):
                 if 'datajson' == export_type:
                     # we didn't check ownership for this type of export, so never load private datasets here
                     packages = DataJsonController._get_ckan_datasets(org=owner_org)
-                    if not packages:
-                        packages = self.get_packages(owner_org=owner_org, with_private=False)
+                    # if not packages:
+                    #     packages = self.get_packages(owner_org=owner_org, with_private=False)
                 else:
                     packages = self.get_packages(owner_org=owner_org, with_private=True)
             else:
@@ -413,7 +413,7 @@ class DataJsonController(BaseController):
 
     @staticmethod
     def _get_ckan_datasets(org=None, with_private=False):
-        n = 100
+        n = 500
         page = int(request.params.get('page', 1))
         dataset_list = []
 

--- a/ckanext/datajson/templates/organization/read.html.bak
+++ b/ckanext/datajson/templates/organization/read.html.bak
@@ -1,5 +1,5 @@
 {% ckan_extends %}
-
+{#
 {% block page_primary_action %}
     {{ super() }}
     {% if h.check_access('package_create', {'owner_org': c.group_dict.id}) %}
@@ -31,3 +31,4 @@
         {% endif %}
     {% endif %}
 {% endblock %}
+#}

--- a/ckanext/datajson/test-inventory/test_wrappers.py
+++ b/ckanext/datajson/test-inventory/test_wrappers.py
@@ -1,0 +1,90 @@
+from ckanext.datajson.package2pod import Wrappers
+
+
+class TestCatalogDateWrapper(object):
+
+    def test_valid_dcat_issued_date(self):
+        Wrappers.pkg = {
+            "title": "Test Dataset",
+            "name": "test-dataset",
+            "metadata_created": "2021-03-26T00:45:51.542432",
+            "metadata_modified": "2021-03-26T00:45:51.542439",
+            "extras": [
+                {
+                    "key": "dcat_issued",
+                    "value": "2019-10-17T23:04:32.000Z"
+                },
+                {
+                    "key": "dcat_modified",
+                    "value": "2021-03-20T00:14:12.000Z"
+                }
+            ]
+        }
+        Wrappers.current_field_map = {
+            "field": "metadata_created",
+            "wrapper": "get_catalog_date"
+        }
+        issued_date = Wrappers.get_catalog_date(Wrappers.pkg.get('metadata_created'))
+        assert issued_date == "2019-10-17T23:04:32.000Z"
+
+
+    def test_valid_dcat_modified_date(self):
+        Wrappers.pkg = {
+            "title": "Test Dataset",
+            "name": "test-dataset",
+            "metadata_created": "2021-03-26T00:45:51.542432",
+            "metadata_modified": "2021-03-26T00:45:51.542439",
+            "extras": [
+                {
+                    "key": "dcat_issued",
+                    "value": "2019-10-17T23:04:32.000Z"
+                },
+                {
+                    "key": "dcat_modified",
+                    "value": "2021-03-20T00:14:12.000Z"
+                }
+            ]
+        }
+        Wrappers.current_field_map = {
+            "field": "metadata_modified",
+            "wrapper": "get_catalog_date"
+        }
+        modified_date = Wrappers.get_catalog_date(Wrappers.pkg.get('metadata_modified'))
+        assert modified_date == "2021-03-20T00:14:12.000Z"
+
+
+    def test_dcat_modified_only_field(self):
+        Wrappers.pkg = {
+            "title": "Test Dataset",
+            "name": "test-dataset",
+            "metadata_created": "2021-03-26T00:45:51.542432",
+            "metadata_modified": "2021-03-26T00:45:51.542439",
+            "extras": [
+                {
+                    "key": "dcat_modified",
+                    "value": "2021-03-20T00:14:12.000Z"
+                }
+            ]
+        }
+        Wrappers.current_field_map = {
+            "field": "metadata_modified",
+            "wrapper": "get_catalog_date"
+        }
+        modified_date = Wrappers.get_catalog_date(Wrappers.pkg.get('metadata_modified'))
+        assert modified_date == "2021-03-26T00:45:51.542439"
+
+
+    def test_no_dcat_in_extras(self):
+        Wrappers.pkg = {
+            "title": "Test Dataset",
+            "name": "test-dataset",
+            "metadata_created": "2021-03-26T00:45:51.542432",
+            "metadata_modified": "2021-03-26T00:45:51.542439",
+            "extras": []
+        }
+        Wrappers.current_field_map = {
+            "field": "metadata_modified",
+            "wrapper": "get_catalog_date"
+        }
+        modified_date = Wrappers.get_catalog_date(Wrappers.pkg.get('metadata_modified'))
+        assert modified_date == "2021-03-26T00:45:51.542439"


### PR DESCRIPTION
This PR adds a wrapper function to display dcat issued and modified dates from the package extras field when available.
This PR also merges changes from the [opengov](https://github.com/OpenGov-OpenData/ckanext-datajson/tree/opengov) branch into master.

## Test
- Install ckanext-datajson plugin and checkout PR
- View `/data.json` and confirm that issued and modified dates appear in dataset metadata