### PR TITLE
[OD-1690] Update accrual periodicity

### DIFF
--- a/ckanext/datajson/package2pod.py
+++ b/ckanext/datajson/package2pod.py
@@ -309,7 +309,8 @@ class Wrappers:
         'notplanned': 'irregular',
         'unknown': 'irregular',
         'not updated': 'irregular',
-        'other': 'irregular'
+        'other': 'irregular',
+        'point in time': 'irregular'
     }
 
     @staticmethod


### PR DESCRIPTION
## Description
According to the Project Open Data Metadata Schema the field `accrualPeriodicity` must be an ISO 8601 repeating duration unless this is not possible because the accrual periodicity is completely irregular, in which case the value should simply be `irregular`.
Below is a link to example values:
https://resources.data.gov/schemas/dcat-us/v1.1/iso8601_guidance/#accrualperiodicity

The value `point in time` is not valid and instead must be displayed as `irregular`.