### PR TITLE
Update mediaType to use correct wrapper

### DIFF
--- a/ckanext/datajson/export_map/bostonma.map.json
+++ b/ckanext/datajson/export_map/bostonma.map.json
@@ -98,7 +98,8 @@
           "field": "url"
         },
         "mediaType": {
-          "field": "mimetype"
+          "field": "format",
+          "wrapper": "mime_type_it"
         },
         "format": {
           "field": "format"

--- a/ckanext/datajson/export_map/cdt.map.json
+++ b/ckanext/datajson/export_map/cdt.map.json
@@ -98,7 +98,8 @@
           "field": "url"
         },
         "mediaType": {
-          "field": "mimetype"
+          "field": "format",
+          "wrapper": "mime_type_it"
         },
         "format": {
           "field": "format"

--- a/ckanext/datajson/export_map/chhs.map.json
+++ b/ckanext/datajson/export_map/chhs.map.json
@@ -98,7 +98,8 @@
           "field": "url"
         },
         "mediaType": {
-          "field": "mimetype"
+          "field": "format",
+          "wrapper": "mime_type_it"
         },
         "format": {
           "field": "format"

--- a/ckanext/datajson/export_map/cnra.map.json
+++ b/ckanext/datajson/export_map/cnra.map.json
@@ -98,7 +98,8 @@
           "field": "url"
         },
         "mediaType": {
-          "field": "mimetype"
+          "field": "format",
+          "wrapper": "mime_type_it"
         },
         "format": {
           "field": "format"

--- a/ckanext/datajson/export_map/export.catalog.map.sample.json
+++ b/ckanext/datajson/export_map/export.catalog.map.sample.json
@@ -103,7 +103,8 @@
           "field": "url"
         },
         "mediaType": {
-          "field": "mimetype"
+          "field": "format",
+          "wrapper": "mime_type_it"
         },
         "format": {
           "field": "format"

--- a/ckanext/datajson/export_map/export.map.json
+++ b/ckanext/datajson/export_map/export.map.json
@@ -103,7 +103,8 @@
           "field": "url"
         },
         "mediaType": {
-          "field": "mimetype"
+          "field": "format",
+          "wrapper": "mime_type_it"
         },
         "format": {
           "field": "format"

--- a/ckanext/datajson/export_map/export.spatial.map.sample.json
+++ b/ckanext/datajson/export_map/export.spatial.map.sample.json
@@ -103,7 +103,8 @@
           "field": "url"
         },
         "mediaType": {
-          "field": "mimetype"
+          "field": "format",
+          "wrapper": "mime_type_it"
         },
         "format": {
           "field": "format"


### PR DESCRIPTION
## Description
This PR fixes the export mappings for the field `mediaType`.
The `mediaType` should be guessed based on the resource format using mime_type_it().

Previously the field was mapped to the resource field `mimetype `, which may not always be populated.
The `ckan.mimetype_guess` option needs to be set in the CKAN configuration for `mimetype` to be set.