### PR TITLE
Update accessURL logic and mediaType defaults

### DIFF
--- a/ckanext/datajson/export_map/bostonma.map.json
+++ b/ckanext/datajson/export_map/bostonma.map.json
@@ -129,7 +129,10 @@
       "field": "tags"
     },
     "language": {
-      "field": "language"
+      "type": "array",
+      "extra": true,
+      "field": "Language",
+      "split": ","
     },
     "references": {
       "type": "array",

--- a/ckanext/datajson/export_map/cnra.map.json
+++ b/ckanext/datajson/export_map/cnra.map.json
@@ -127,7 +127,10 @@
       "field": "tags"
     },
     "language": {
-      "field": "language"
+      "type": "array",
+      "extra": true,
+      "field": "Language",
+      "split": ","
     },
     "references": {
       "type": "array",

--- a/ckanext/datajson/package2pod.py
+++ b/ckanext/datajson/package2pod.py
@@ -414,6 +414,27 @@ class Wrappers:
 
     @staticmethod
     def generate_distribution(someValue):
+        accessurl_formats = [
+            'api',
+            'arcgis map preview',
+            'arcgis map service',
+            'arcgis online map',
+            'chart',
+            'esri rest',
+            'gtfs',
+            'htm',
+            'html',
+            'map',
+            'url',
+            'wcs',
+            'web',
+            'web link',
+            'web page',
+            'website',
+            'wfs',
+            'wms',
+            'wmts'
+        ]
 
         arr = []
         package = Wrappers.pkg
@@ -455,7 +476,11 @@ class Wrappers:
             if res_url:
                 res_url = res_url.replace('http://[[REDACTED', '[[REDACTED')
                 res_url = res_url.replace('http://http', 'http')
-                if r.get('resource_type') in ['api', 'accessurl']:
+                if (
+                    r.get('resource_type') in ['api', 'accessurl']
+                    or r.get('format', '').lower() in accessurl_formats
+                    or not r.get('format')
+                ):
                     resource['accessURL'] = res_url
                     if 'mediaType' in resource:
                         resource.pop('mediaType')
@@ -513,14 +538,15 @@ class Wrappers:
 
     @staticmethod
     def mime_type_it(value):
+        mime_type = 'application/octet-stream'
         if not value:
-            return value
+            return mime_type
         formats = h.resource_formats()
         format_clean = value.lower()
         if format_clean in formats:
             mime_type = formats[format_clean][0]
-        else:
-            mime_type = value
+        if not mime_type:
+            mime_type = 'application/octet-stream'
         msg = value + ' ... BECOMES ... ' + mime_type
         log.debug(msg)
         return mime_type


### PR DESCRIPTION
## Description
This PR updates the logic for displaying `accessURL` based on resource formats. According to the [Project Open Data Metadata Schema](https://resources.data.gov/resources/dcat-us/#distribution-accessURL) the `accessURL` field should be for indirect access to a dataset like an API or website.

Another change is to set the default value of the `mediaType` field to "application/octet-stream". Previously if a matching mime type was not found the resource's format would be returned, which is usually not a valid mime type.

## Screenshots
![Screen Shot 2021-07-08 at 8 00 23 PM](https://user-images.githubusercontent.com/4096633/125004304-3dcb1d80-e027-11eb-96c4-6e1c2b0a10c2.png)
