### PR TITLE
Fix page validation in ckan 2.9

### DIFF
--- a/ckanext/datajson/blueprint.py
+++ b/ckanext/datajson/blueprint.py
@@ -354,7 +354,7 @@ def validator():
 
         body = None
         try:
-            body = requests.get(c.source_url).json()
+            body = requests.get(c.source_url, timeout=60).json()
         except IOError as e:
             c.errors.append(('Error Loading File', ['The address could not be loaded: ' + str(e)]))
         except ValueError as e:

--- a/ckanext/datajson/blueprint.py
+++ b/ckanext/datajson/blueprint.py
@@ -27,6 +27,7 @@ datapusher = Blueprint('datajson', __name__)
 
 logger = logging.getLogger(__name__)
 draft4validator = get_validator()
+is_positive_integer = p.toolkit.get_validator('is_positive_integer')
 _errors_json = []
 _zip_name = ''
 
@@ -379,8 +380,12 @@ def _get_ckan_datasets(org=None, with_private=False):
     '''
     Gets CKAN datasets with pagination for a max 5000 datasets per page
     '''
-    n = 500
-    page = int(request.params.get('page', 1))
+    n = 1000
+    try:
+        page = is_positive_integer(request.params.get('page', 1), {})
+    except p.toolkit.Invalid:
+        return []
+
     dataset_list = []
 
     # Set max number of results returned per page
@@ -393,7 +398,8 @@ def _get_ckan_datasets(org=None, with_private=False):
     if org:
         fq += ' AND organization:' + org
 
-    # Get 500 datasets at a time until we reach 5000 or there are no more
+    # Call package_search, getting n datasets at a time, until either
+    # max_result is reached or there are no more datasets.
     for x in range(int(max_result / n)):
         search_data_dict = {
             'q': q,

--- a/ckanext/datajson/harvester_cmsdatanavigator.py
+++ b/ckanext/datajson/harvester_cmsdatanavigator.py
@@ -25,7 +25,7 @@ class CmsDataNavigatorHarvester(DatasetHarvesterBase):
         }
 
     def load_remote_catalog(self, harvest_job):
-        catalog = requests.get(harvest_job.source.url).json()
+        catalog = requests.get(harvest_job.source.url, timeout=60).json()
         for item in catalog:
             item["identifier"] = item["ID"]
             item["title"] = item["Name"].strip()

--- a/ckanext/datajson/harvester_datajson.py
+++ b/ckanext/datajson/harvester_datajson.py
@@ -23,7 +23,7 @@ class DataJsonHarvester(DatasetHarvesterBase):
 
     def load_remote_catalog(self, harvest_job):
         try:
-            response = requests.get(harvest_job.source.url, headers={"User-agent": "Data.gov/2.0"})
+            response = requests.get(harvest_job.source.url, headers={"User-agent": "Data.gov/2.0"}, timeout=60)
             response.raise_for_status()
         except HTTPError as e:
             self._save_gather_error("HTTP Error getting json source: %s." % (e), harvest_job)

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,8 @@ omit=ckanext/datajson/tests/*
 
 [flake8]
 max-line-length = 127
-ignore = E402  # TODO disable once future.standard_libary is removed
+# TODO disable once future.standard_libary is removed
+ignore = E402
 
 [tool:pytest]
 norecursedirs=ckanext/datajson/tests/nose


### PR DESCRIPTION
## Description
Validate that the page parameter is a positive integer. If it's not then return no datasets.
Also add timeout to requests.