### PR TITLE
Fix mapping of license field

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,7 +35,7 @@ jobs:
       image: openknowledge/ckan-dev:${{ matrix.ckan-version }}
     services:
       solr:
-        image: ckan/ckan-solr-dev:${{ matrix.ckan-version }}
+        image: ckan/ckan-solr:${{ matrix.ckan-version }}
       postgres:
         image: ckan/ckan-postgres-dev:${{ matrix.ckan-version }}
         env:

--- a/ckanext/datajson/export_map/bostonma.map.json
+++ b/ckanext/datajson/export_map/bostonma.map.json
@@ -49,8 +49,8 @@
       "field": "url"
     },
     "license": {
-      "extra": true,
-      "field": "license"
+      "field": "license_url",
+      "wrapper": "get_license"
     },
     "primaryITInvestmentUII": {
       "extra": true,

--- a/ckanext/datajson/export_map/cdt.map.json
+++ b/ckanext/datajson/export_map/cdt.map.json
@@ -49,8 +49,8 @@
       "field": "program_web_page"
     },
     "license": {
-      "extra": true,
-      "field": "license"
+      "field": "license_url",
+      "wrapper": "get_license"
     },
     "primaryITInvestmentUII": {
       "extra": true,

--- a/ckanext/datajson/export_map/chhs.map.json
+++ b/ckanext/datajson/export_map/chhs.map.json
@@ -49,8 +49,8 @@
       "field": "program_web_page"
     },
     "license": {
-      "extra": true,
-      "field": "license"
+      "field": "license_url",
+      "wrapper": "get_license"
     },
     "primaryITInvestmentUII": {
       "extra": true,

--- a/ckanext/datajson/export_map/cnra.map.json
+++ b/ckanext/datajson/export_map/cnra.map.json
@@ -49,8 +49,8 @@
       "field": "url"
     },
     "license": {
-      "extra": true,
-      "field": "license"
+      "field": "license_url",
+      "wrapper": "get_license"
     },
     "primaryITInvestmentUII": {
       "extra": true,

--- a/ckanext/datajson/export_map/export.catalog.map.sample.json
+++ b/ckanext/datajson/export_map/export.catalog.map.sample.json
@@ -50,8 +50,8 @@
       "field": "landingPage"
     },
     "license": {
-      "extra": true,
-      "field": "license"
+      "field": "license_url",
+      "wrapper": "get_license"
     },
     "primaryITInvestmentUII": {
       "extra": true,

--- a/ckanext/datajson/export_map/export.map.json
+++ b/ckanext/datajson/export_map/export.map.json
@@ -50,8 +50,8 @@
       "field": "landingPage"
     },
     "license": {
-      "extra": true,
-      "field": "license"
+      "field": "license_url",
+      "wrapper": "get_license"
     },
     "primaryITInvestmentUII": {
       "extra": true,

--- a/ckanext/datajson/package2pod.py
+++ b/ckanext/datajson/package2pod.py
@@ -561,3 +561,11 @@ class Wrappers(object):
             elif catalog_date_field == 'metadata_modified':
                 return dcat_modified
         return date_value
+
+    @staticmethod
+    def get_license(value):
+        if value:
+            return value
+        license_title = Wrappers.pkg.get('license_title')
+        if license_title != 'License not specified':
+            return license_title

--- a/ckanext/datajson/tests/test_wrappers.py
+++ b/ckanext/datajson/tests/test_wrappers.py
@@ -85,3 +85,49 @@ class TestCatalogDateWrapper(object):
         }
         modified_date = Wrappers.get_catalog_date(Wrappers.pkg.get('metadata_modified'))
         assert modified_date == "2021-03-26T00:45:51.542439"
+
+
+class TestGetLicenseWrapper(object):
+
+    def test_valid_license_url(self):
+        Wrappers.pkg = {
+            "title": "Test Dataset",
+            "name": "test-dataset",
+            "license_id": "cc-by",
+            "license_title": "Creative Commons Attribution",
+            "license_url": "http://www.opendefinition.org/licenses/cc-by"
+        }
+        Wrappers.current_field_map = {
+            "field": "license_url",
+            "wrapper": "get_license"
+        }
+        license = Wrappers.get_license(Wrappers.pkg.get('license_url'))
+        assert license == "http://www.opendefinition.org/licenses/cc-by"
+
+    def test_no_license_url(self):
+        Wrappers.pkg = {
+            "title": "Test Dataset",
+            "name": "test-dataset",
+            "license_id": "other-open",
+            "license_title": "Other (Open)"
+        }
+        Wrappers.current_field_map = {
+            "field": "license_url",
+            "wrapper": "get_license"
+        }
+        license = Wrappers.get_license(Wrappers.pkg.get('license_url'))
+        assert license == "Other (Open)"
+
+    def test_no_license_url_and_no_license_title(self):
+        Wrappers.pkg = {
+            "title": "Test Dataset",
+            "name": "test-dataset",
+            "license_id": None,
+            "license_title": None
+        }
+        Wrappers.current_field_map = {
+            "field": "license_url",
+            "wrapper": "get_license"
+        }
+        license = Wrappers.get_license(Wrappers.pkg.get('license_url'))
+        assert license is None


### PR DESCRIPTION
# Description
Fix mapping of license field to DCAT schema.
According to the DCAT schema the license field should be provided as a url.
However, some licenses in ckan do not have a license url so we provide the title instead.